### PR TITLE
Remove matplotlib dependency

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,9 +12,8 @@
 
 ## Requirements
 
-`sai` works on Linux operating systems and tested with the following:
+`sai` works on Linux operating systems and is tested with the following:
 
-- matplotlib=3.9.1
 - natsort=8.4.0
 - numpy=1.26.4
 - pandas=2.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 ]
 
 dependencies = [
-    "matplotlib==3.9.1",
     "natsort==8.4.0",
     "numpy==1.26.4",
     "pandas==2.2.1",


### PR DESCRIPTION
## Summary by Sourcery

Remove matplotlib as a project dependency and update documentation accordingly.

Enhancements:
- Streamline runtime dependencies by dropping the unused matplotlib requirement.

Documentation:
- Update documented dependency list to no longer mention matplotlib.