### PR TITLE
Allow missing genotypes in SAI allele frequency calculation

### DIFF
--- a/sai/generators/window_generator.py
+++ b/sai/generators/window_generator.py
@@ -114,7 +114,7 @@ class WindowGenerator(DataGenerator):
             filter_ref=False,
             filter_tgt=False,
             filter_src=False,
-            filter_missing=True,
+            filter_missing=False,
         )
 
         self.ref_data = results["ref"][0]

--- a/sai/stats/stat_utils.py
+++ b/sai/stats/stat_utils.py
@@ -19,36 +19,37 @@
 
 
 import numpy as np
+import allel
 from typing import Tuple, Optional, Union
 
 
 def calc_freq(gts: np.ndarray, ploidy: int = 1) -> np.ndarray:
     """
-    Calculates allele frequencies, supporting both phased and unphased data.
+    Calculate the frequency of allele 1 per site.
 
     Parameters
     ----------
     gts : np.ndarray
-        A 2D numpy array where each row represents a locus and each column represents an individual.
-    ploidy : int, optional
-        Ploidy level of the organism. If ploidy=1, the function assumes phased data and calculates
-        frequency by taking the mean across individuals. For unphased data, it calculates frequency by
-        dividing the sum across individuals by the total number of alleles. Default is 1.
+        Genotype data.
+    ploidy : int
+        Ploidy level.
 
     Returns
     -------
     np.ndarray
-        An array of allele frequencies for each locus.
-
-    Raises
-    ------
-    ValueError
-        If ploidy is not a positive integer.
+        ALT allele frequency per locus.
     """
     if not isinstance(ploidy, int) or ploidy <= 0:
         raise ValueError("ploidy must be a positive integer.")
 
-    return np.sum(gts, axis=1) / (gts.shape[1] * ploidy)
+    mask = gts < 0  # remove missing data as scikit-allel converts missing data to -1
+    called = (~mask).sum(axis=1)
+
+    num = np.where(~mask, gts, 0).sum(axis=1, dtype=float)
+    den = called * ploidy
+
+    out = np.full(gts.shape[0], np.nan, dtype=float)
+    return np.divide(num, den, out=out, where=den > 0)
 
 
 def compute_matching_loci(
@@ -117,6 +118,17 @@ def compute_matching_loci(
         for src_gts, ploidy_val in zip(src_gts_list, ploidy[2:])
     ]
 
+    valid = (
+        np.isfinite(ref_freq)
+        & (ref_freq >= 0)
+        & (ref_freq <= 1)
+        & np.isfinite(tgt_freq)
+        & (tgt_freq >= 0)
+        & (tgt_freq <= 1)
+    )
+    for src_freq in src_freq_list:
+        valid &= np.isfinite(src_freq) & (src_freq >= 0) & (src_freq <= 1)
+
     # Check match for each `y`
     op_funcs = {
         "=": lambda src_freq, y: src_freq == y,
@@ -141,7 +153,7 @@ def compute_matching_loci(
         all_match = all_match_y | all_match_1_minus_y
 
         # Identify loci where all sources match `1 - y` for frequency inversion
-        inverted = all_match_1_minus_y
+        inverted = all_match_1_minus_y & valid
 
         # Invert frequencies for these loci
         ref_freq[inverted] = 1 - ref_freq[inverted]
@@ -149,8 +161,9 @@ def compute_matching_loci(
     else:
         all_match = all_match_y
 
-    # Final condition: locus must satisfy source matching and have `ref_freq < w`
-    condition = all_match & (ref_freq < w)
+    # Final condition: locus must satisfy source matching and have `ref_freq < w` and have valid frequency
+    # condition = all_match & (ref_freq < w)
+    condition = valid & all_match & (ref_freq < w)
 
     return ref_freq, tgt_freq, condition
 

--- a/sai/utils/utils.py
+++ b/sai/utils/utils.py
@@ -177,11 +177,6 @@ def read_geno_data(
         if filter_missing:
             if np.any(missing_mask):
                 chrom_data = filter_geno_data(chrom_data, ~missing_mask)
-        else:
-            if np.any(missing_mask):
-                raise ValueError(
-                    "Missing data is found. Please remove variants with missing data or enable filtering."
-                )
 
         if anc_alleles:
             chrom_data = check_anc_allele(chrom_data, anc_alleles, chr_name)

--- a/tests/stats/test_stat_utils.py
+++ b/tests/stats/test_stat_utils.py
@@ -36,6 +36,18 @@ def test_phased_data():
     )
 
 
+def test_phased_data_with_missing_data():
+    gts = np.array([[1, -1, -1, 1], [-1, -1, -1, -1], [1, -1, 1, 1]])
+    expected_frequency = np.array([1.0, np.nan, 1.0])
+    result = calc_freq(gts, ploidy=1)
+    np.testing.assert_array_almost_equal(
+        result,
+        expected_frequency,
+        decimal=6,
+        err_msg="Phased data with missing data test failed.",
+    )
+
+
 def test_unphased_diploid_data():
     # Unphased data, ploidy = 2 (diploid)
     gts = np.array([[1, 1], [0, 0], [2, 2]])
@@ -46,6 +58,18 @@ def test_unphased_diploid_data():
         expected_frequency,
         decimal=6,
         err_msg="Unphased diploid data test failed.",
+    )
+
+
+def test_unphased_diploid_data_with_missing_data():
+    gts = np.array([[1, -1], [0, 0], [-2, 2]])
+    expected_frequency = np.array([0.5, 0.0, 1.0])
+    result = calc_freq(gts, ploidy=2)
+    np.testing.assert_array_almost_equal(
+        result,
+        expected_frequency,
+        decimal=6,
+        err_msg="Unphased diploid data with missing data test failed.",
     )
 
 


### PR DESCRIPTION
This PR modifies several SAI scripts to allow missing genotypes
when calculating allele counts and allele frequencies.

Main changes:
- Allow missing genotypes in allele count calculation
- Avoid inflated allele frequencies when missing data are present
- Ensure Q95 statistics remain within valid ranges

Thanks for taking a look!
I’ve enabled “Allow edits by maintainers” so feel free to push small fixes directly.

## Summary by Sourcery

Allow SAI statistics and window generation to handle missing genotypes when computing allele frequencies and selecting loci.

New Features:
- Support scikit-allel GenotypeArray inputs alongside NumPy arrays when computing ALT allele frequencies.
- Allow haploid ALT-indicator genotype arrays with missing data to be used in allele frequency calculations.

Bug Fixes:
- Prevent inflated or invalid allele frequencies and Q95 statistics by ignoring missing genotypes and filtering out loci with non-finite or out-of-range frequencies.

Enhancements:
- Add validation of allele frequencies across reference, target, and source populations when computing matching loci.
- Treat loci with inverted frequencies as valid only when all frequencies are finite and within [0, 1].

Chores:
- Stop raising errors on the presence of missing genotype data and disable missing-data filtering by default in the window generator.