### PR TITLE
Add Pepy downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![build status](https://img.shields.io/github/actions/workflow/status/xin-huang/sai/build.yaml?branch=main&style=flat-square)](https://github.com/xin-huang/sai/actions)
 [![codecov](https://img.shields.io/codecov/c/github/xin-huang/sai?style=flat-square)](https://app.codecov.io/gh/xin-huang/sai)
 [![docs](https://img.shields.io/github/actions/workflow/status/xin-huang/sai/pages/pages-build-deployment?style=flat-square&label=docs)](https://github.com/xin-huang/sai/deployments/github-pages)
+[![downloads](https://img.shields.io/pepy/dt/sai-pg?style=flat-square)](https://pepy.tech/projects/sai-pg)
 
 A Python Package for **S**tatistics for **A**daptive **I**ntrogression
 


### PR DESCRIPTION
### Motivation
- Add a visible download metric to project README by including a Pepy downloads badge in `README.md`.

### Description
- Inserted a new downloads badge linked to Pepy into `README.md` to display package download counts.

### Testing
- No automated tests were run because this change is documentation-only and does not affect code or tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a686a64c832cab7b70acd8d0ed1e)

## Summary by Sourcery

Documentation:
- Add a Pepy-based downloads badge to README.md to display package download statistics.